### PR TITLE
Fix decimal serialization

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -79,13 +79,18 @@ function test_serializeInteger() {
 }
 
 function test_serializeDecimal() {
-  assert.deepStrictEqual(serializeDecimal(0), "0") // 0.0 is 0 in JS
-  assert.deepStrictEqual(serializeDecimal(1.0), "1") // 1.0 is 1 in JS
+  assert.deepStrictEqual(serializeDecimal(0), "0.0")
+  assert.deepStrictEqual(serializeDecimal(1.0), "1.0")
   assert.deepStrictEqual(serializeDecimal(1.01), "1.01")
+  assert.deepStrictEqual(serializeDecimal(1.0021), "1.002")
+  assert.deepStrictEqual(serializeDecimal(1.0029), "1.003")
+  assert.deepStrictEqual(serializeDecimal(1.0025), "1.002")
+  assert.deepStrictEqual(serializeDecimal(1.0035), "1.004")
+  assert.deepStrictEqual(serializeDecimal(-1.0035), "-1.004")
   assert.deepStrictEqual(serializeDecimal( 999_999_999_999.999),  "999999999999.999")
   assert.deepStrictEqual(serializeDecimal(-999_999_999_999.999), "-999999999999.999")
-  assert.throws(() => serializeInteger( 1_000_000_000_000_000.1))
-  assert.throws(() => serializeInteger(-1_000_000_000_000_000.1))
+  assert.throws(() => serializeDecimal( 1_000_000_000_000.0))
+  assert.throws(() => serializeDecimal(-1_000_000_000_000.0))
 }
 
 function test_serializeString() {


### PR DESCRIPTION
`serializeDecimal` did not implement all of the steps outlined:

```
// 4.1.5.  Serializing a Decimal
//
// Given a decimal number as input_decimal, return an ASCII string
// suitable for use in a HTTP field value.
//
// 1.   If input_decimal is not a decimal number, fail serialization.
//
// 2.   If input_decimal has more than three significant digits to the
//      right of the decimal point, round it to three decimal places,
//      rounding the final digit to the nearest value, or to the even
//      value if it is equidistant.
//
// 3.   If input_decimal has more than 12 significant digits to the left
//      of the decimal point after rounding, fail serialization.
//
// 4.   Let output be an empty string.
//
// 5.   If input_decimal is less than (but not equal to) 0, append "-"
//      to output.
//
// 6.   Append input_decimal's integer component represented in base 10
//      (using only decimal digits) to output; if it is zero, append
//      "0".
//
// 7.   Append "." to output.
//
// 8.   If input_decimal's fractional component is zero, append "0" to
//      output.
//
// 9.   Otherwise, append the significant digits of input_decimal's
//      fractional component represented in base 10 (using only decimal
//      digits) to output.
//
// 10.  Return output.
```

This PR fixes this by:
  * putting the correct character limit on integer part
  * append `.0` if there is no decimal part
  * implement 'even rounding'
  * fix/add tests