### PR TITLE
remove bigint as it is not universally supported yet

### DIFF
--- a/index.js
+++ b/index.js
@@ -378,7 +378,7 @@ export function serializeBareItem(value) {
  * @return {string}
  */
 export function serializeInteger(value) {
-  if (value < -999_999_999_999_999n || 999_999_999_999_999n < value) throw new Error(`failed to serialize ${value} as Integer`)
+  if (Math.abs(value).toString().length > 15) throw new Error(`failed to serialize ${value} as Integer`)
   return value.toString()
 }
 


### PR DESCRIPTION
This makes the package more universal.

Some linters do not support `BigInts` as they are not yet part of the ECMAScript standard:
https://stackoverflow.com/a/55978107


So we get errors like:
```
Parse errors in imported module 'structured-field-values': 
---
Identifier directly after number (381:18)

  379 |  */
  380 | export function serializeInteger(value) {
> 381 |   if (value < -999_999_999_999_999n || 999_999_999_999_999n < value) throw new Error(`failed to serialize ${value} as Integer`)
      |                   ^
  382 |   return value.toString()
  ```
  
  